### PR TITLE
Add Claude Code review workflow for pull requests

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,34 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  claude-review:
+    if: |
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          model: "claude-sonnet-4-20250514"
+          direct_prompt: |
+            Review this pull request for:
+            1. Security issues (credential exposure, injection, OWASP top 10)
+            2. Code quality (type safety, error handling, test coverage)
+            3. Consistency with existing patterns in the codebase
+            4. Breaking changes or backwards compatibility concerns
+
+            Focus on actionable feedback. Be concise.


### PR DESCRIPTION
## Summary
Adds automated Claude Code review on all pull requests targeting main, plus interactive @claude mentions in PR comments.

## Changes
- New `.github/workflows/claude-review.yml` using `anthropics/claude-code-action@v1`
- Reviews for security issues, code quality, pattern consistency, and breaking changes
- Triggered on PR open/sync/reopen and @claude comment mentions

## Setup Required
- Add `ANTHROPIC_API_KEY` as a repository secret in Settings > Secrets and variables > Actions

## Also Done
- Enabled branch protection on `main`: requires `test-gate` status check, PR required, no force pushes, dismiss stale reviews

## Test plan
- [ ] Verify ANTHROPIC_API_KEY secret is configured
- [ ] Open a test PR to validate the workflow triggers
- [ ] Comment @claude on a PR to test interactive review