### PR TITLE
Fix docs, PyPI metadata, and stale references from expert review

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -24,7 +24,7 @@ body:
     attributes:
       label: Environment
       description: OS, Python version, agentsec version.
-      placeholder: Windows 11, Python 3.14.2, agentsec 0.4.1
+      placeholder: Windows 11, Python 3.14.2, agentsec 0.4.4
     validations:
       required: true
   - type: textarea

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="License"></a>
+  <a href="https://github.com/debu-sinha/agentsec/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="License"></a>
   <a href="https://www.python.org/"><img src="https://img.shields.io/badge/python-3.10%2B-blue.svg" alt="Python"></a>
   <a href="https://github.com/debu-sinha/agentsec/actions/workflows/ci.yml"><img src="https://github.com/debu-sinha/agentsec/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://pypi.org/project/agentsec-ai/"><img src="https://img.shields.io/pypi/v/agentsec-ai.svg" alt="PyPI"></a>
@@ -13,15 +13,11 @@
 
 # agentsec
 
-Security scanner and hardener for agentic AI installations.
+**Static configuration scanner and hardener for AI agent installations.** Detects misconfigurations, credential leaks, supply-chain risks, and MCP tool poisoning — then maps every finding to the [OWASP Top 10 for Agentic Applications (2026)](https://genai.owasp.org/).
 
-agentsec focuses on practical misconfigurations and supply-chain risk in:
-- OpenClaw installations
-- MCP server configurations and code
-- Agent skill/plugin ecosystems
-- Credential exposure in local files
+Supports OpenClaw, Claude Code, Cursor, Windsurf, Gemini CLI, and MCP server ecosystems.
 
-All findings map to the OWASP Top 10 for Agentic Applications (2026).
+> **Scope:** agentsec performs static configuration and file analysis. It does not provide runtime protection, behavioral monitoring, or real-time threat detection. Use as one layer in a defense-in-depth strategy.
 
 ## Quick Start
 
@@ -43,11 +39,11 @@ agentsec scan ~/.openclaw
 | `installation` | Gateway exposure, auth posture, DM/group policy, tool/sandbox settings, SSRF and safety checks, known CVE version checks, sensitive file/dir permissions |
 | `skill` | Instruction malware, risky code patterns (`eval/exec/subprocess`), prompt-injection patterns, frontmatter capability risk, dependency/install-hook risk |
 | `mcp` | Tool poisoning patterns, auth gaps on remote endpoints, dangerous schema/permissions, unverified `npx` usage |
-| `credential` | 17 secret patterns (OpenAI, Anthropic, AWS, GitHub, Slack, Stripe, etc.), high-entropy detection, git credential leakage |
+| `credential` | detect-secrets engine (23 plugins) + 11 custom patterns (OpenAI, Anthropic, AWS, Databricks, HuggingFace, etc.), high-entropy detection, git credential leakage |
 
 Reference catalog:
-- [checks-catalog.md](docs/checks-catalog.md) (27 named checks + dynamic credential findings)
-- [CLI reference](docs/cli-reference.md) (full command/options guide)
+- [Checks Catalog](https://github.com/debu-sinha/agentsec/blob/main/docs/checks-catalog.md) (27 named checks + dynamic credential findings)
+- [CLI Reference](https://github.com/debu-sinha/agentsec/blob/main/docs/cli-reference.md) (full command/options guide)
 
 ## Core Commands
 
@@ -81,6 +77,9 @@ agentsec watch ~/.openclaw -i 2
 # Pre-install package gate (scan before install)
 agentsec gate npm install express
 
+# Pin MCP tool descriptions for rug-pull detection
+agentsec pin-tools
+
 # Generate shell hook wrappers for npm/pip install flows
 agentsec hook --shell zsh
 ```
@@ -110,8 +109,9 @@ Output formats:
 
 Exit codes:
 - `0`: no findings at/above threshold
-- `1-127`: count of findings at/above threshold (capped)
-- `2`: runtime/usage error
+- `1`: findings found at/above threshold
+- `2`: usage error (e.g., unknown scanner name)
+- `3`: runtime error (e.g., file access failure)
 
 ## GitHub Actions
 
@@ -129,7 +129,7 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@v4
-      - uses: debu-sinha/agentsec@v0.4.1
+      - uses: debu-sinha/agentsec@v0.4.4
         with:
           fail-on: high
           output: sarif
@@ -137,7 +137,7 @@ jobs:
 ```
 
 Action definition:
-- [action.yml](action.yml)
+- [action.yml](https://github.com/debu-sinha/agentsec/blob/main/action.yml)
 
 ## Screenshots
 
@@ -145,36 +145,33 @@ Screenshots below show the experimental demo sandbox flow (intentionally insecur
 
 ### Step 1: Initial scan on intentionally insecure demo config
 
-![agentsec scan - intentionally insecure demo config](docs/demo/screenshots/scan-before.png)
+![agentsec scan - intentionally insecure demo config](https://raw.githubusercontent.com/debu-sinha/agentsec/main/docs/demo/screenshots/scan-before.png)
 
 ### Step 2: Apply workstation hardening profile
 
-![agentsec harden - workstation profile applied](docs/demo/screenshots/harden-apply.png)
+![agentsec harden - workstation profile applied](https://raw.githubusercontent.com/debu-sinha/agentsec/main/docs/demo/screenshots/harden-apply.png)
 
 ### Step 3: Re-scan findings after hardening
 
-![agentsec scan - post-hardening findings](docs/demo/screenshots/scan-after-findings.png)
+![agentsec scan - post-hardening findings](https://raw.githubusercontent.com/debu-sinha/agentsec/main/docs/demo/screenshots/scan-after-findings.png)
 
 ### Step 4: OWASP posture view after hardening
 
-![agentsec scan - OWASP posture after hardening](docs/demo/screenshots/scan-after-posture.png)
+![agentsec scan - OWASP posture after hardening](https://raw.githubusercontent.com/debu-sinha/agentsec/main/docs/demo/screenshots/scan-after-posture.png)
 
 ## MCP Ecosystem Security Dashboard
 
 Weekly automated security scan of the top 50 MCP server repositories, graded A through F.
 
-[![Ecosystem Grade](https://img.shields.io/badge/Ecosystem_Grade-B-green?style=flat-square)](docs/mcp-security-grades.md) [![Repos Scanned](https://img.shields.io/badge/Repos_Scanned-50-blue?style=flat-square)](docs/mcp-security-grades.md)
+[![Ecosystem Grade](https://img.shields.io/badge/Ecosystem_Grade-B-green?style=flat-square)](https://github.com/debu-sinha/agentsec/blob/main/docs/mcp-security-grades.md) [![Repos Scanned](https://img.shields.io/badge/Repos_Scanned-50-blue?style=flat-square)](https://github.com/debu-sinha/agentsec/blob/main/docs/mcp-security-grades.md)
 
-**[View the full dashboard](docs/mcp-security-grades.md)** - updated every Monday via GitHub Actions.
+**[View the full dashboard](https://github.com/debu-sinha/agentsec/blob/main/docs/mcp-security-grades.md)** - updated every Monday via GitHub Actions.
 
 ## Benchmarks and Studies
 
-- [Fixture benchmark (artifact filename keeps v0.4.0; refreshed 2026-02-17 with agentsec v0.4.1)](docs/benchmarks/results/2026-02-15-v0.4.0.md)  
-  Precision/recall/F1 over a 20-fixture suite.
-- [Top-50 MCP study (snapshot 2026-02-16)](docs/benchmarks/2026-02-top50-mcp-security-study.md)  
-  Agentsec-only repro run with normalized findings output.
-- [Top-50 study kit](docs/benchmarks/top50/README.md)  
-  Schema, selection CSV, JSONL findings, and summary JSON.
+- [Fixture benchmark](https://github.com/debu-sinha/agentsec/blob/main/docs/benchmarks/results/2026-02-15-v0.4.0.md) — precision/recall/F1 over a 20-fixture suite (self-authored fixtures, not independently validated).
+- [Top-50 MCP study](https://github.com/debu-sinha/agentsec/blob/main/docs/benchmarks/2026-02-top50-mcp-security-study.md) — agentsec-only repro run with normalized findings output.
+- [Top-50 study kit](https://github.com/debu-sinha/agentsec/blob/main/docs/benchmarks/top50/README.md) — schema, selection CSV, JSONL findings, and summary JSON.
 
 Current checked-in Top-50 summary data:
 - `docs/benchmarks/top50/reports/top50_summary_20260215.json`
@@ -204,15 +201,15 @@ python scripts/repo_consistency_audit.py
 
 ## Case Studies
 
-- [001: Insecure workstation remediation](docs/case-studies/001-insecure-openclaw-workstation.md)
-- [002: Public bot hardening on VPS](docs/case-studies/002-public-bot-vps-hardening.md)
-- [003: Pre-install gate blocked malicious package](docs/case-studies/003-preinstall-gate-blocked-malicious-package.md)
-- [004: Malicious skill detection and block](docs/case-studies/004-malicious-skill-detection-and-block.md)
+- [001: Insecure workstation remediation](https://github.com/debu-sinha/agentsec/blob/main/docs/case-studies/001-insecure-openclaw-workstation.md)
+- [002: Public bot hardening on VPS](https://github.com/debu-sinha/agentsec/blob/main/docs/case-studies/002-public-bot-vps-hardening.md)
+- [003: Pre-install gate blocked malicious package](https://github.com/debu-sinha/agentsec/blob/main/docs/case-studies/003-preinstall-gate-blocked-malicious-package.md)
+- [004: Malicious skill detection and block](https://github.com/debu-sinha/agentsec/blob/main/docs/case-studies/004-malicious-skill-detection-and-block.md)
 
 ## Launch Evidence
 
-- [Launch Evidence Manifest](docs/launch/LAUNCH_EVIDENCE_MANIFEST.md)
-- [Reproducibility Spec](docs/launch/REPRODUCIBILITY_SPEC.md)
+- [Launch Evidence Manifest](https://github.com/debu-sinha/agentsec/blob/main/docs/launch/LAUNCH_EVIDENCE_MANIFEST.md)
+- [Reproducibility Spec](https://github.com/debu-sinha/agentsec/blob/main/docs/launch/REPRODUCIBILITY_SPEC.md)
 
 ## Development
 
@@ -225,23 +222,21 @@ pytest
 ```
 
 Contribution guide:
-- [CONTRIBUTING.md](CONTRIBUTING.md)
+- [CONTRIBUTING.md](https://github.com/debu-sinha/agentsec/blob/main/CONTRIBUTING.md)
 
 Security policy:
-- [SECURITY.md](SECURITY.md)
+- [SECURITY.md](https://github.com/debu-sinha/agentsec/blob/main/SECURITY.md)
 
 ## Governance
 
-- [Code of Conduct](CODE_OF_CONDUCT.md)
-- [Security Policy](SECURITY.md)
-- [Contribution Guide](CONTRIBUTING.md)
+- [Code of Conduct](https://github.com/debu-sinha/agentsec/blob/main/CODE_OF_CONDUCT.md)
+- [Security Policy](https://github.com/debu-sinha/agentsec/blob/main/SECURITY.md)
+- [Contribution Guide](https://github.com/debu-sinha/agentsec/blob/main/CONTRIBUTING.md)
 
 Issue intake is template-driven under `.github/ISSUE_TEMPLATE/` to keep triage and reproduction quality high.
 ## License
 
 Apache-2.0
-
-
 
 
 

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
     required: false
     default: ''
   version:
-    description: 'agentsec-ai version to install (e.g. "0.4.1"). Empty = latest.'
+    description: 'agentsec-ai version to install (e.g. "0.4.4"). Empty = latest.'
     required: false
     default: ''
   python-version:

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -27,6 +27,7 @@ agentsec --version
 - `watch` - watch files and re-scan on relevant changes.
 - `show-profile` - inspect profile changes before hardening.
 - `hook` - generate shell wrappers for auto post-install scans.
+- `pin-tools` - pin MCP tool descriptions for rug-pull detection.
 - `list-scanners` - show available scanner modules.
 
 ## scan
@@ -208,6 +209,31 @@ Behavior summary:
 - Blocks immediately on known-malicious blocklist hits.
 - Blocks findings at/above `--fail-on` unless `--force` is used.
 - If allowed and not dry-run, executes the real package-manager command.
+
+## pin-tools
+
+Pin MCP tool descriptions to detect rug-pull attacks (tool description drift).
+
+```bash
+agentsec pin-tools [TARGET]
+```
+
+Creates or updates `.agentsec-pins.json` with SHA-256 hashes of current tool descriptions. Subsequent scans compare live descriptions against pinned hashes and flag changes.
+
+Examples:
+
+```bash
+# Pin tool descriptions in current directory
+agentsec pin-tools
+
+# Pin tools for a specific installation
+agentsec pin-tools ~/.openclaw
+```
+
+Findings produced on drift:
+
+- **Description changed** (HIGH): tool description differs from pinned hash.
+- **Tool removed** (MEDIUM): a previously pinned tool is no longer present.
 
 ## JSON and SARIF
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "agentsec-ai"
 version = "0.4.4"
-description = "Security scanner and hardener for agentic AI installations — OpenClaw, MCP servers, and AI agent skill ecosystems"
+description = "Security scanner for AI agents and MCP servers. OWASP Agentic Top 10 mapping, SARIF output, CI/CD ready."
 readme = {file = "README.md", content-type = "text/markdown"}
 license = "Apache-2.0"
 requires-python = ">=3.10"
@@ -13,7 +13,7 @@ authors = [
     { name = "Debu Sinha", email = "debusinha2009@gmail.com" },
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: Apache Software License",
@@ -22,6 +22,8 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Environment :: Console",
+    "Operating System :: OS Independent",
     "Topic :: Security",
     "Topic :: Software Development :: Quality Assurance",
     "Topic :: System :: Systems Administration",
@@ -30,12 +32,20 @@ classifiers = [
 keywords = [
     "security",
     "agentic-ai",
+    "ai-agent",
     "openclaw",
     "mcp",
     "model-context-protocol",
     "vulnerability-scanner",
     "owasp",
     "ai-security",
+    "sast",
+    "credential-scanner",
+    "secret-detection",
+    "sarif",
+    "supply-chain-security",
+    "claude-code",
+    "llm-security",
 ]
 dependencies = [
     "click>=8.1,<9",
@@ -71,6 +81,7 @@ Homepage = "https://github.com/debu-sinha/agentsec"
 Documentation = "https://github.com/debu-sinha/agentsec#readme"
 Repository = "https://github.com/debu-sinha/agentsec"
 Issues = "https://github.com/debu-sinha/agentsec/issues"
+Changelog = "https://github.com/debu-sinha/agentsec/blob/main/CHANGELOG.md"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/agentsec"]

--- a/tests/unit/test_gate.py
+++ b/tests/unit/test_gate.py
@@ -1,7 +1,6 @@
 """Tests for the pre-install security gate."""
 
 import json
-import os
 import tarfile
 import zipfile
 
@@ -283,11 +282,13 @@ def test_tar_traversal_blocked(tmp_path):
         info.size = len(data)
         tar.addfile(info, io.BytesIO(data))
 
-    with tarfile.open(tar_path, "r:gz") as tar:
-        # Python 3.12+ raises OutsideDestinationError (via filter="data"),
-        # older versions raise our ValueError
-        with pytest.raises((ValueError, tarfile.OutsideDestinationError)):
-            _extract_tar_archive(tar, extract_dir)
+    # Python 3.12+ raises OutsideDestinationError (via filter="data"),
+    # older versions raise our ValueError
+    with (
+        tarfile.open(tar_path, "r:gz") as tar,
+        pytest.raises((ValueError, tarfile.OutsideDestinationError)),
+    ):
+        _extract_tar_archive(tar, extract_dir)
 
 
 def test_zip_traversal_blocked(tmp_path):
@@ -320,6 +321,8 @@ def test_tar_symlink_blocked(tmp_path):
         info.linkname = "/etc/passwd"
         tar.addfile(info)
 
-    with tarfile.open(tar_path, "r:gz") as tar:
-        with pytest.raises(ValueError, match="link entry"):
-            _extract_tar_archive(tar, extract_dir)
+    with (
+        tarfile.open(tar_path, "r:gz") as tar,
+        pytest.raises(ValueError, match="link entry"),
+    ):
+        _extract_tar_archive(tar, extract_dir)


### PR DESCRIPTION
## Summary

Remediates CRITICAL and HIGH findings from a 5-agent expert review (Technical Docs, Visual Assets, PyPI Strategist, CISO Enterprise, Developer Experience).

## Changes

### README.md
- Fix 4 screenshot paths (relative → absolute raw.githubusercontent.com URLs) so images render on PyPI
- Add scope disclaimer: "static configuration and file analysis" — not runtime protection
- Add multi-platform support list (Claude Code, Cursor, Windsurf, Gemini CLI)
- Update credential scanner description (17 patterns → detect-secrets 23 plugins + 11 custom)
- Fix exit codes section (was incorrect range, now matches actual behavior)
- Add `pin-tools` to Core Commands
- Convert 15+ relative doc links to absolute GitHub URLs for PyPI rendering
- Add benchmark disclaimer ("self-authored fixtures, not independently validated")
- Update GitHub Action version reference (v0.4.1 → v0.4.4)
- Remove trailing blank lines

### pyproject.toml
- Rewrite description for PyPI search visibility
- Upgrade classifier: Alpha → Beta
- Add Environment::Console and OS Independent classifiers
- Add 8 keywords for PyPI discoverability
- Add Changelog URL

### docs/checks-catalog.md
- Fix CGW-001 detection description (gatewayHostname → gateway.bind)
- Fix CEX-002 description (defaultApproval: always → defaults.security: full)
- Add missing OWASP cross-references (ASI10 to CGW-003, ASI08 to CTO-002/CTO-003)
- Update credential detection section to match actual detect-secrets + custom pattern architecture
- Fix entropy threshold documentation

### docs/cli-reference.md
- Add pin-tools to Command Overview
- Add full pin-tools documentation section

### action.yml / bug_report.yml
- Update version references from 0.4.1 → 0.4.4

### tests/unit/test_gate.py
- Remove unused `import os` (ruff F401)
- Combine nested `with` statements (ruff SIM117)

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format src/ tests/` — clean
- [x] `pytest tests/ -v --tb=short` — 356 passed, 2 skipped, 4 xfail