### PR TITLE
Suppress KeywordDetector false positives (0.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to agentsec are documented here.
 
+## [0.5.1] - 2026-06-14
+
+False-positive reduction from a deeper pass over the top-50 MCP ecosystem scan,
+focused on the credential scanner's KeywordDetector results. No repo, path, or
+value is hardcoded; each fix is a generic shape rule with a regression test.
+
+### Fixed
+
+- Suppress KeywordDetector matches whose value is a descriptive identifier
+  rather than a secret: enum/const string values and OAuth method names such as
+  `SecurityApiKey`, `clientSecretBasic`, `security.apiKey`, `CryptoService`,
+  `password_auth`. Scoped to KeywordDetector so provider keys (AWS, Private Key,
+  OpenAI, etc.) are never affected.
+- Suppress KeywordDetector values that are validation regex patterns
+  (`AIza[0-9A-Za-z-_]{35}`, `sk-[a-zA-Z0-9]{20}`) or CI templating expressions
+  (`${{ secrets.GITHUB_TOKEN }}`).
+- Treat localization / i18n files (`locales/`, `i18n/`, `*.lang.ts`,
+  `*.i18n.json`) as low-confidence context; translated UI strings were tripping
+  keyword detection.
+
 ## [0.5.0] - 2026-06-04
 
 Threat-coverage refresh aligned with the 2026 MCP and agent-skill disclosure wave.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ authors:
 repository-code: "https://github.com/debu-sinha/agentsec"
 url: "https://pypi.org/project/agentsec-ai/"
 license: Apache-2.0
-version: "0.5.0"
-date-released: "2026-06-05"
+version: "0.5.1"
+date-released: "2026-06-14"
 keywords:
   - security
   - ai-agents

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentsec-ai"
-version = "0.5.0"
+version = "0.5.1"
 description = "Security scanner for AI agents and MCP servers. OWASP Agentic Top 10 mapping, SARIF output, CI/CD ready."
 readme = {file = "README.md", content-type = "text/markdown"}
 license = "Apache-2.0"

--- a/src/agentsec/__init__.py
+++ b/src/agentsec/__init__.py
@@ -13,7 +13,7 @@ Quickstart::
         print(f"{finding.severity.value}: {finding.title}")
 """
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 from agentsec.models.config import AgentsecConfig, ScannerConfig, ScanTarget
 from agentsec.models.findings import (

--- a/src/agentsec/scanners/credential.py
+++ b/src/agentsec/scanners/credential.py
@@ -466,6 +466,15 @@ _LOW_CONFIDENCE_DIRS: set[str] = {
     "mocks",
     "testutils",
     "test_helpers",
+    # Localization / i18n: translated UI strings trip keyword detectors but are
+    # not credentials.
+    "locales",
+    "locale",
+    "i18n",
+    "translations",
+    "lang",
+    "langs",
+    "intl",
 }
 
 # Loopback hosts in a connection/basic-auth string: dev scaffolding, not a
@@ -489,6 +498,44 @@ def _line_in_test_block(lines: list[str], idx: int, window: int = 40) -> bool:
     start = max(0, idx - window)
     end = min(idx + 1, len(lines))
     return any(_TEST_BLOCK_MARKERS.search(lines[i]) for i in range(start, end))
+
+
+def _looks_like_identifier_phrase(value: str) -> bool:
+    """True when ``value`` is a descriptive identifier rather than a secret.
+
+    Splits on separators and camelCase boundaries; if the result is two or more
+    real word tokens (each 3-12 alpha chars) plus optional short numbers, it is
+    an enum/const/method name (e.g. "SecurityApiKey", "clientSecretBasic",
+    "password_auth"), not a random credential. Real high-entropy keys decompose
+    into short two-character fragments and are not matched.
+    """
+    if len(value) > 40:
+        return False
+    tokens: list[str] = []
+    for part in re.split(r"[-_.:/\s]", value):
+        if not part:
+            continue
+        camel = re.findall(r"[A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+|\d+", part)
+        tokens.extend(camel if camel else [part])
+    if len(tokens) < 2:
+        return False
+    words = [t for t in tokens if t.isalpha() and 3 <= len(t) <= 12]
+    digits = [t for t in tokens if t.isdigit() and len(t) <= 4]
+    return len(words) >= 2 and (len(words) + len(digits)) == len(tokens)
+
+
+def _looks_like_regex_pattern(value: str) -> bool:
+    """True when ``value`` is a regex/validation pattern, not a literal secret.
+
+    Matches values containing a character class plus quantifier (``[..]{n}``),
+    regex escapes (``\\d``/``\\w``/``\\s``), or a non-capturing group (``(?:``).
+    """
+    return bool(
+        re.search(r"\[[^\]]+\]\s*[*+{]", value)
+        or re.search(r"\\[dwsDWS]", value)
+        or "(?:" in value
+        or "(?<" in value
+    )
 
 
 # Files that intentionally contain fake/example secrets: the configs and
@@ -731,6 +778,19 @@ class CredentialScanner(BaseScanner):
                     if not secret.secret_value:
                         continue
                     if self._shannon_entropy(secret.secret_value) < 3.0:
+                        continue
+                    # KeywordDetector captures the value after a `password=`/
+                    # `secret=`/`token=` keyword. Suppress the common non-secret
+                    # shapes it picks up: descriptive enum/const identifiers,
+                    # validation regex patterns, and CI templating expressions.
+                    # These checks are scoped to this detector only so provider
+                    # keys (AWS, Private Key, etc.) are never affected.
+                    sv = secret.secret_value
+                    if (
+                        _looks_like_identifier_phrase(sv)
+                        or _looks_like_regex_pattern(sv)
+                        or "${{" in sv
+                    ):
                         continue
 
                 severity = _SEVERITY_MAP.get(secret.type, FindingSeverity.MEDIUM)
@@ -1396,6 +1456,9 @@ class CredentialScanner(BaseScanner):
             return True
         # Secret-scanner config/allowlist files (deliberately hold fake tokens)
         if name_lower in _SECRET_SCANNER_CONFIG_FILES:
+            return True
+        # Localization message files: en-US.lang.ts, messages.i18n.json, etc.
+        if ".lang." in name_lower or ".i18n." in name_lower or ".messages." in name_lower:
             return True
         # Mock/stub/fixture/dummy/example files
         if "mock" in name_lower or "stub" in name_lower or "fixture" in name_lower:

--- a/tests/unit/test_credential_scanner_adversarial.py
+++ b/tests/unit/test_credential_scanner_adversarial.py
@@ -1031,7 +1031,8 @@ class TestFP_Ecosystem_v050:
         d.mkdir(parents=True)
         (d / "zh-CN.json").write_text(
             '{\n  "accessPasswordTip": "服务端 API 鉴权，避免 API 被外部应用盗用。",\n'
-            '  "apiKeyPlaceholder": "请输入模型 API 密钥"\n}\n'
+            '  "apiKeyPlaceholder": "请输入模型 API 密钥"\n}\n',
+            encoding="utf-8",
         )
         findings = scanner.scan(ScanContext(target_path=tmp_path))
         assert all(fd.severity == FindingSeverity.LOW for fd in findings)

--- a/tests/unit/test_credential_scanner_adversarial.py
+++ b/tests/unit/test_credential_scanner_adversarial.py
@@ -987,3 +987,58 @@ class TestFP_Ecosystem_v050:
         )
         findings = scanner.scan(ScanContext(target_path=tmp_path))
         assert any(fd.severity == FindingSeverity.CRITICAL for fd in findings)
+
+    def test_keyword_identifier_values_suppressed(self, scanner, tmp_path):
+        """KeywordDetector captures enum/const/method-name string values that
+        are descriptive identifiers, not secrets (opensumi, webiny, agentgateway
+        in the 2026-06-05 scan)."""
+        f = tmp_path / "constants.ts"
+        f.write_text(
+            'const SECRET_KEY = "CryptoService";\n'
+            'const API_KEY = "SecurityApiKey";\n'
+            'const method = "clientSecretBasic";\n'
+        )
+        findings = scanner.scan(ScanContext(target_path=tmp_path))
+        kw = [fd for fd in findings if fd.metadata.get("detector") == "Secret Keyword"]
+        assert kw == [], "descriptive identifier values must not flag as secrets"
+
+    def test_keyword_regex_pattern_value_suppressed(self, scanner, tmp_path):
+        """A validation regex used as a value is not a secret
+        (BeehiveInnovations/pal-mcp-server run-server.ps1)."""
+        f = tmp_path / "run-server.ps1"
+        f.write_text(
+            "$patterns = @{\n"
+            '    "GEMINI_API_KEY" = "AIza[0-9A-Za-z-_]{35}"\n'
+            '    "OPENAI_API_KEY" = "sk-[a-zA-Z0-9]{20}"\n'
+            "}\n"
+        )
+        findings = scanner.scan(ScanContext(target_path=tmp_path))
+        assert all(fd.severity == FindingSeverity.LOW for fd in findings)
+
+    def test_keyword_ci_expression_suppressed(self, scanner, tmp_path):
+        """GitHub Actions ${{ secrets.* }} expressions are references, not
+        literal secrets (grafana, awslabs workflows)."""
+        f = tmp_path / "ci.yaml"
+        f.write_text("env:\n  token: ${{ secrets.GITHUB_TOKEN }}\n")
+        findings = scanner.scan(ScanContext(target_path=tmp_path))
+        kw = [fd for fd in findings if fd.metadata.get("detector") == "Secret Keyword"]
+        assert kw == []
+
+    def test_i18n_locale_file_low_confidence(self, scanner, tmp_path):
+        """Translated UI strings in locale files are not credentials
+        (u14app/deep-research, opensumi)."""
+        d = tmp_path / "src" / "locales"
+        d.mkdir(parents=True)
+        (d / "zh-CN.json").write_text(
+            '{\n  "accessPasswordTip": "服务端 API 鉴权，避免 API 被外部应用盗用。",\n'
+            '  "apiKeyPlaceholder": "请输入模型 API 密钥"\n}\n'
+        )
+        findings = scanner.scan(ScanContext(target_path=tmp_path))
+        assert all(fd.severity == FindingSeverity.LOW for fd in findings)
+
+    def test_custom_secret_outside_identifier_shape_still_flagged(self, scanner, tmp_path):
+        """Guard: a real high-entropy custom secret after a keyword still flags."""
+        f = tmp_path / "app.py"
+        f.write_text('API_SECRET = "xQ7zP2mK9wL4nR8tV3yB6dH1jF5gC0aW"\n')
+        findings = scanner.scan(ScanContext(target_path=tmp_path))
+        assert any(fd.metadata.get("detector") == "Secret Keyword" for fd in findings)


### PR DESCRIPTION
## Summary

Second false-positive pass over the top-50 MCP ecosystem scan, focused on the
credential scanner's detect-secrets KeywordDetector results. These produced ~73
medium "Secret Keyword" findings that were not secrets. Ships as 0.5.1.

Result on the same corpus: **medium "Secret Keyword" 73 -> 22 (-70%)**. The
remaining matches are genuinely ambiguous (telemetry keys, datastore config,
config-schema prose) where further suppression would risk missing real secrets.

## Changes

All fixes are scoped to KeywordDetector, so provider-key detectors (AWS, Private
Key, OpenAI, etc.) are never affected. Each has a regression test.

- Suppress descriptive identifier values: enum/const strings and OAuth method
  names such as `SecurityApiKey`, `clientSecretBasic`, `security.apiKey`,
  `CryptoService`, `password_auth`. Detected by splitting on separators and
  camelCase into real word tokens; high-entropy keys decompose into two-char
  fragments and are kept.
- Suppress validation-regex values (`AIza[0-9A-Za-z-_]{35}`, `sk-[a-zA-Z0-9]{20}`)
  and CI templating expressions (`${{ secrets.GITHUB_TOKEN }}`).
- Treat localization / i18n files (`locales/`, `i18n/`, `*.lang.ts`) as
  low-confidence context.
- Regenerate the dashboard (grade A, 93/100).

## Testing Performed

### Local Unit
- `pytest tests/ -q` -> 658 passed, 2 skipped, 3 xfailed (5 new tests).
  Guard tests confirm real high-entropy custom secrets, AWS keys, and private
  keys still flag.
- `ruff check src/ tests/` -> clean.

### Read-only Smoke Test
- Top-50 ecosystem rerun: medium Secret Keyword 73 -> 22; each remaining match
  spot-checked as ambiguous or legitimate, not a clear FP.

## Risk & Rollback

Low. KeywordDetector-scoped suppression only; provider detectors untouched.
Guard tests prevent over-suppression. Rollback is a branch revert.

## Docs

- CHANGELOG 0.5.1 entry; version bumped in pyproject, __init__, CITATION.